### PR TITLE
feat: deploy 워크플로우 개선 (MACHINE_TOKEN, 실패 피드백)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,16 +19,8 @@ on:
 jobs:
   merge-pr:
     if: ${{ inputs.comment_body == '/deploy' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - name: 브랜치 결정
-        id: branch
-        env:
-          GH_TOKEN: ${{ secrets.MACHINE_TOKEN || github.token }}
-        run: |
-          REF=$(gh pr view ${{ inputs.issue_number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)
-          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@v4
         with:
           ref: develop
@@ -39,9 +31,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin "${{ steps.branch.outputs.ref }}"
-          git merge --no-ff "origin/${{ steps.branch.outputs.ref }}" \
-            -m "Merge ${{ steps.branch.outputs.ref }} into develop"
+          git fetch origin pull/${{ inputs.issue_number }}/head:pr-branch
+          git merge --no-ff pr-branch -m "Merge PR #${{ inputs.issue_number }} to develop"
           git push origin develop
 
       - name: 리액션

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,35 +19,26 @@ on:
 jobs:
   merge-pr:
     if: ${{ inputs.comment_body == '/deploy' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - name: 브랜치 결정
-        id: branch
-        env:
-          GH_TOKEN: ${{ secrets.MACHINE_TOKEN || github.token }}
-        run: |
-          REF=$(gh pr view ${{ inputs.issue_number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)
-          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
-
-      - uses: actions/checkout@v4
+      - name: Check out the repository
+        uses: actions/checkout@v4
         with:
           ref: develop
           fetch-depth: 0
           token: ${{ secrets.MACHINE_TOKEN || github.token }}
 
-      - name: Merge and push
+      - name: Merge PR to develop
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin "${{ steps.branch.outputs.ref }}"
-          git merge --no-ff "origin/${{ steps.branch.outputs.ref }}" \
-            -m "Merge ${{ steps.branch.outputs.ref }} into develop"
+          PR_NUMBER=${{ inputs.issue_number }}
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git fetch origin pull/$PR_NUMBER/head:pr-branch
+          git merge pr-branch --no-ff -m "Merge PR #$PR_NUMBER to develop"
           git push origin develop
 
-      - name: 리액션
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.MACHINE_TOKEN || github.token }}
-        run: |
-          EMOJI=${{ job.status == 'success' && '"+1"' || '"-1"' }}
-          gh api repos/${{ github.repository }}/issues/comments/${{ inputs.comment_id }}/reactions -f content="$EMOJI"
+      - name: Add end emoji reaction to the comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ inputs.comment_id }}
+          reaction-type: 'rocket'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,27 +16,35 @@ on:
 jobs:
   merge-pr:
     if: ${{ inputs.comment_body == '/deploy' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-
-      - name: Fetch all history for all tags and branches
-        run: git fetch --prune --unshallow
-
-      - name: Merge PR to develop
+      - name: 브랜치 결정
+        id: branch
+        env:
+          GH_TOKEN: ${{ secrets.MACHINE_TOKEN || github.token }}
         run: |
-          PR_NUMBER=${{ inputs.issue_number }}
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git fetch origin pull/$PR_NUMBER/head:pr-branch
-          git checkout develop
-          git merge pr-branch --no-ff -m "Merge PR #$PR_NUMBER to develop"
+          REF=$(gh pr view ${{ inputs.issue_number }} --repo ${{ github.repository }} --json headRefName -q .headRefName)
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.MACHINE_TOKEN || github.token }}
+
+      - name: Merge and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin "${{ steps.branch.outputs.ref }}"
+          git merge --no-ff "origin/${{ steps.branch.outputs.ref }}" \
+            -m "Merge ${{ steps.branch.outputs.ref }} into develop"
           git push origin develop
 
-      - name: Add end emoji reaction to the comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          comment-id: ${{ inputs.comment_id }}
-          reaction-type: 'rocket'
+      - name: 리액션
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.MACHINE_TOKEN || github.token }}
+        run: |
+          EMOJI=${{ job.status == 'success' && '"+1"' || '"-1"' }}
+          gh api repos/${{ github.repository }}/issues/comments/${{ inputs.comment_id }}/reactions -f content="$EMOJI"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ on:
       comment_body:
         required: true
         type: string
+    secrets:
+      MACHINE_TOKEN:
+        required: false
 
 jobs:
   merge-pr:


### PR DESCRIPTION
## 배경

공용 deploy 워크플로우(`/deploy` PR 코멘트 → develop 머지)를 개선합니다.
TASK-5371 develop 브랜치 보호의 일부로, ruleset bypass를 위한 MACHINE_TOKEN 지원과 실패 피드백을 추가합니다.

## 변경사항

- `gh pr view`로 브랜치 결정 (기존 `git fetch origin pull/N/head` 방식 제거)
- `ref: develop` + `fetch-depth: 0` checkout (기존 `--prune --unshallow` 제거)
- `MACHINE_TOKEN` secret 입력 추가 (`required: false`, 없으면 `github.token` fallback)
- 성공/실패 리액션 (+1/-1, `if: always()`) 추가 (기존: 성공 시 rocket만)

## 검증

- caller가 MACHINE_TOKEN을 넘기지 않는 경우: `github.token` fallback으로 기존 동작 유지
- caller가 MACHINE_TOKEN을 넘기는 경우: ruleset bypass로 develop push 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)