### PR TITLE
feat(build_v2): freeDiskSpace 옵션 추가

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -20,6 +20,9 @@
 #   - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY secrets 제거
 # v2.8 - 박기영
 #   - workflow level outputs에 tag 추가
+# v2.9 - 류호선
+#   - freeDiskSpace 옵션 추가 (기본값: false)
+#   - true 시 빌드 전 사전 설치 도구 제거로 ~14GB 디스크 확보
 name: Build
 
 on:
@@ -111,7 +114,7 @@ jobs:
     - name: Free disk space
       if: ${{ inputs.freeDiskSpace }}
       run: |
-        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$RUNNER_TOOL_CACHE"
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -67,6 +67,11 @@ on:
       buildContext:
         required: false
         type: string
+      freeDiskSpace:
+        required: false
+        type: boolean
+        default: false
+        description: Free disk space before build by removing pre-installed tools (.NET, Haskell, Boost, etc.)
 
     outputs:
       tag:
@@ -103,6 +108,11 @@ jobs:
       cancel-in-progress: ${{ inputs.env == 'prd' }}
 
     steps:
+    - name: Free disk space
+      if: ${{ inputs.freeDiskSpace }}
+      run: |
+        sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+
     - name: Checkout
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Summary
- `build_v2.yml`에 `freeDiskSpace` boolean input 추가 (기본값: `false`)
- `true` 전달 시 빌드 전 사전 설치 도구 제거 (~14GB 확보)
  - `/usr/share/dotnet` (~6GB)
  - `/opt/ghc` (~2GB)
  - `/usr/local/share/boost` (~1.5GB)
  - `$AGENT_TOOLSDIRECTORY` (~5GB)
- 기존 워크플로우 동작 변경 없음

## 사용법
```yaml
uses: team-monolith-product/tmn-gh-actions/.github/workflows/build_v2.yml@main
with:
  freeDiskSpace: true
  # ... 기존 inputs
```

## 배경
- `codle-course-maker` 레포의 `public/` 에셋이 1.1GB로 증가
- GitHub-hosted runner(ubuntu-22.04) 디스크 한계(~22GB) 초과로 빌드 실패
- 이 옵션으로 ~14GB 추가 확보 가능