### PR TITLE
INF-227 build_v2 의 buildContext="." 일 때 tag prefix 미적용

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -23,6 +23,10 @@
 # v2.9 - 류호선
 #   - freeDiskSpace 옵션 추가 (기본값: false)
 #   - true 시 빌드 전 사전 설치 도구 제거로 ~14GB 디스크 확보
+# v2.10 - 박기영
+#   - buildContext 가 "." 또는 "./" 이면 tag prefix 를 붙이지 않도록 수정.
+#     기존에는 prefix 가 ".-" 가 되어 ECR tag 가 invalid reference format 으로
+#     빌드가 실패했다. 명시적 sub-directory context 만 prefix 로 활용한다.
 name: Build
 
 on:
@@ -133,8 +137,11 @@ jobs:
       env:
         CONTEXT: ${{ inputs.buildContext }}
       run: |
+        # buildContext 가 "." 또는 "./" 처럼 repo root 를 가리키면 prefix 를 붙이지 않는다.
+        # 그렇지 않으면 ECR tag 가 ".-2026-05-26T..." 같은 invalid reference format 이 된다.
+        # 명시적 sub-directory (예: "apps/foo") 만 tag prefix 로 활용.
         PREFIX=''
-        if [ -n "$CONTEXT" ]; then
+        if [ -n "$CONTEXT" ] && [ "$CONTEXT" != "." ] && [ "$CONTEXT" != "./" ]; then
           PREFIX="$CONTEXT-"
         fi
         echo "tag=${PREFIX}$(TZ='Asia/Seoul' date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 자산 변경 목적

`build_v2.yml` 의 `Name tag` step 이 `buildContext` 가 `"."` 일 때도 `PREFIX="$CONTEXT-"` 를 적용해 ECR tag 가 `.-2026-05-26T...` 같은 invalid reference format 으로 빌드 실패하는 문제를 fix.

`tmn-stateless-hub` 의 wheel-build stage 에서 setuptools_scm file-finder 가 `.git` 디렉토리 부재로 `git ls-files` 빈 결과를 반환해 비-py 파일이 wheel 에서 누락되는 문제 ([tmn-stateless-hub#2](https://github.com/team-monolith-product/tmn-stateless-hub/pull/2) 참조) 의 근본 fix 로 호출 워크플로우에서 `buildContext: .` 을 명시해 file 시스템 context 를 강제하려 한다. 그 명시가 invalid tag 를 만들지 않도록 본 PR 로 prefix 로직을 보완.

## 변경 사항

- `Name tag` step 의 PREFIX 조건에 `"$CONTEXT" != "." && "$CONTEXT" != "./"` 추가. repo root 를 가리키는 케이스는 prefix 대상이 아님.
- 헤더 주석에 v2.10 항목 추가.

호출 측이 `buildContext` 를 명시하지 않는 기존 사용자에는 영향 없음 (CONTEXT 가 빈 string 이라 기존 분기 그대로 `PREFIX=""`).

## 성능 영향 검토

없음. 단일 shell 조건 추가.

## 보안 영향 검토

없음.

## 관련 작업

- 노션 INF-227: https://www.notion.so/3681cc820da680a5b46ef2c316796355
- 호출 측 PR: https://github.com/team-monolith-product/tmn-stateless-hub/pull/2