### PR TITLE
feat: Dependabot 자동 병합 reusable workflow 추가

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,57 @@
+name: Dependabot Auto-Merge
+
+# Dependabot PR 중 안전한 버전 업데이트를 자동 승인 + auto-merge 활성화합니다.
+# 실제 병합은 GitHub auto-merge가 base 브랜치 ruleset의 required status checks
+# 통과를 기다렸다가 수행하므로, CI 게이트는 각 레포의 ruleset이 담당합니다.
+#
+# 자동 병합 허용 조건 (PR에 포함된 모든 의존성이 만족해야 함):
+# - semver-patch 업데이트
+# - semver-minor 업데이트 중 이전 버전이 0.x가 아닌 것
+#   (0.x의 minor 변경은 semver 관례상 breaking으로 간주하여 차단,
+#    이전 버전을 파싱할 수 없는 minor 업데이트도 보수적으로 차단)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Evaluate update policy
+        id: policy
+        env:
+          UPDATED_DEPENDENCIES: '${{ steps.metadata.outputs.updated-dependencies-json }}'
+        run: |
+          eligible=$(echo "$UPDATED_DEPENDENCIES" | jq '
+            (length > 0) and all(.[];
+              .updateType == "version-update:semver-patch"
+              or (
+                .updateType == "version-update:semver-minor"
+                and ((.prevVersion // "") != "")
+                and ((.prevVersion | ltrimstr("v") | startswith("0.")) | not)
+              )
+            )
+          ')
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+          echo "updated-dependencies: $UPDATED_DEPENDENCIES"
+          echo "eligible: $eligible"
+
+      - name: Approve and enable auto-merge
+        if: steps.policy.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          PR_URL: '${{ github.event.pull_request.html_url }}'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL" || gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
## 배경

Org 전역 Dependabot 도입에 따라 minor 이하 + CI 통과 PR을 자동 병합합니다. 중앙 폴링 방식(tmn-workflow-automation#123, 파기) 대신 플랫폼 네이티브 구조를 사용합니다:

- 업데이트 등급 판별은 `dependabot/fetch-metadata`(정본, 그룹 PR 지원)
- 리뷰 요건은 `github-actions[bot]`의 approve로 충족 (admin bypass 불필요)
- CI 대기는 GitHub auto-merge + 각 레포 ruleset의 required status checks

## 변경사항

- `dependabot-automerge.yml`: `workflow_call` reusable workflow. 각 레포에는 무로직 caller만 배포됩니다(tmn-workflow-automation 동기화 스크립트, 별도 PR).
- 허용 정책: 모든 의존성이 semver-patch이거나, semver-minor 중 이전 버전이 0.x가 아닌 경우. 0.x minor는 semver 관례상 breaking으로 차단, 이전 버전 파싱 불가 minor도 보수적으로 차단.

## 검증

- jq 정책 식을 9개 케이스(1.x minor 허용 / 0.x minor 차단 / major 차단 / 그룹 혼합 / prevVersion 누락·null / 빈 배열)로 로컬 검증, 전부 기대값 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)