### PR TITLE
fix: build_v2 빌드 이미지 provenance 비활성화 (ECR 스캔 정상화)

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -211,6 +211,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         push: true
+        provenance: false
         tags: ${{ steps.tags.outputs.tags }}
         secrets: |
           ${{ secrets.DOCKER_SECRETS }}

--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -23,6 +23,9 @@
 # v2.9 - 류호선
 #   - freeDiskSpace 옵션 추가 (기본값: false)
 #   - true 시 빌드 전 사전 설치 도구 제거로 ~14GB 디스크 확보
+# v2.10 - 이창환
+#   - build-push 에 provenance: false 추가
+#   - attestation 으로 인한 OCI image index 생성을 막아 ECR BASIC 스캔 정상화
 name: Build
 
 on:
@@ -211,6 +214,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         push: true
+        # ECR BASIC 스캔은 OCI image index 를 못 읽으므로 단일 매니페스트로 강제 (단일 amd64 빌드라 attestation 손실 없음)
         provenance: false
         tags: ${{ steps.tags.outputs.tags }}
         secrets: |


### PR DESCRIPTION
## 배경

ECR 취약점 스캔 현황을 점검하다가, `scanOnPush=true` 인 리포조차 최신 이미지에 스캔 기록이 전혀 없는(`imageScanStatus: null`) 문제를 발견했습니다.

원인은 푸시되는 이미지가 단일 매니페스트가 아니라 OCI image index(`application/vnd.oci.image.index.v1+json`) 라는 점입니다. 인덱스 자식을 확인하면 `linux/amd64` 이미지 1개 + `attestation-manifest` 1개로, 실제 멀티아치가 아니라 provenance attestation 때문에 인덱스로 감싸진 것이었습니다. ECR BASIC 스캔은 image index 를 스캔하지 못하므로 스캔이 사실상 무력화됩니다.

`docker/build-push-action@v5` 는 buildx 컨테이너 드라이버로 push 할 때 provenance attestation 을 기본 생성합니다. 이 워크플로(`build_v2.yml`)는 159개 레포가 공유하므로, 여기 한 줄이 전체에 영향을 줍니다.

## 변경 사항

`build_v2.yml` 의 build-push 스텝에 `provenance: false` 추가.

```yaml
    - name: Build and push
      uses: docker/build-push-action@v5
      with:
        push: true
        provenance: false
        ...
```

빌드는 amd64 단일 플랫폼이므로 attestation 제거에 따른 런타임 손실이 없고, 산출물이 단일 매니페스트가 되어 ECR BASIC 스캔이 동작합니다.

## 검증

- `build_v2.yml` YAML 파싱 정상

## 비고

- 스캔을 실제로 켜는 설정(`aws_ecr_registry_scanning_configuration`)은 ped-terraform 별도 PR 로 진행합니다. 적용 순서는 이 PR(빌드 산출물을 단일 매니페스트로) → 스캔 활성화 순서가 되어야 첫 푸시부터 결과가 쌓입니다.
- v1 `build.yml` 은 현재 main 에 존재하지 않아 대상에서 제외했습니다.