### PR TITLE
fix: build_v2 develop 에 provenance:false 반영 (ECR BASIC 스캔 정상화)

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -20,6 +20,10 @@
 #   - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY secrets 제거
 # v2.8 - 박기영
 #   - workflow level outputs에 tag 추가
+# v2.10 - 이창환
+#   - build-push 에 provenance: false 추가
+#   - attestation 으로 인한 OCI image index 생성을 막아 ECR BASIC 스캔 정상화
+#   - main(#24)에서 develop 으로 우선 반영. v2.9(freeDiskSpace)는 미반영 상태
 name: Build
 
 on:
@@ -198,6 +202,8 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         push: true
+        # ECR BASIC 스캔은 OCI image index 를 못 읽으므로 단일 매니페스트로 강제 (단일 amd64 빌드라 attestation 손실 없음)
+        provenance: false
         tags: ${{ steps.tags.outputs.tags }}
         secrets: |
           ${{ secrets.DOCKER_SECRETS }}


### PR DESCRIPTION
# 배경

ECR 레지스트리 BASIC scan-on-push 가 활성화됐으나(ped-terraform #843, 적용 완료) 스캔 결과가 한 건도 잡히지 않음. 원인은 모든 이미지가 OCI image index 로 푸시되고 있고, BASIC 스캔은 image index 를 읽지 못해 조용히 건너뛰기 때문.

index 제거 fix(`provenance: false`)는 `main` 에만 반영됨(#24). 그런데 소비 레포의 빌드 워크플로는 다음과 같이 갈려 있음:

- `build-prd.yml` → `build_v2.yml@main` (fix 있음)
- `build-dev.yml` → `build_v2.yml@develop` (fix 없음)

따라서 모든 `*-dev` 이미지는 계속 OCI index 로 올라가 영구 미스캔 상태. 오늘(06-12) 빌드된 `tmn-ecr-live-tweaker-all-dev` 도 index 로 확인됨.

# 변경 사항

`develop` 의 `build_v2.yml` 에 `main(#24)` 과 동일한 `provenance: false` 를 반영. 단일 amd64 빌드라 attestation 손실은 없음.

v2.9(freeDiskSpace)는 develop 에 미반영 상태이나 이번 범위 밖이라 건드리지 않음.

# 검증

- diff 는 changelog 항목 + `provenance: false` 두 곳뿐(+6 라인).
- 머지 후 dev 빌드가 단일 매니페스트로 푸시되는지 1회 확인 필요.