### PR TITLE
fix(helm-template-check): pull_request에서 PR 브랜치를 직접 체크아웃

### DIFF
--- a/.github/workflows/helm-template-check.yml
+++ b/.github/workflows/helm-template-check.yml
@@ -21,6 +21,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # pull_request의 detached merge HEAD가 아니라 실제 PR 브랜치를 체크아웃한다.
+          # 이게 없으면 아래 git-auto-commit(기본 branch=github.head_ref)이 커밋 전
+          # `git checkout <head_ref>`로 브랜치를 바꾸다가, 포맷팅으로 더러워진 워킹트리와
+          # merge HEAD/브랜치 tip의 파일 내용 차이로 "local changes would be overwritten" 에러가 난다.
+          ref: ${{ github.head_ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

재사용 워크플로 `helm-template-check.yml`이 `pull_request`에서 실패하는 버그를 고친다. Checkout 스텝에 `ref: ${{ github.head_ref }}` 한 줄을 추가한다.

**왜:** 이 워크플로를 호출하는 PR에서 다음 에러로 죽고 있었다.

```
error: Your local changes to the following files would be overwritten by checkout:
	entry-express/aws-apne2-prd-service.yaml
Please commit your changes or stash them before you switch branches.
Aborting
Error: Invalid status code: 1  (stefanzweifel/git-auto-commit-action@v5)
```

## 근본 원인

1. 트리거가 `pull_request`라 `actions/checkout@v4`가 `ref` 없이 **detached merge HEAD**(`refs/pull/N/merge`)를 체크아웃한다.
2. `eslint --fix` + `prettier --write .`가 워킹트리의 YAML을 재포맷해 커밋 안 된 변경을 만든다.
3. `git-auto-commit-action@v5`는 `branch` 입력 **기본값이 `${{ github.head_ref }}`** 라서, 커밋 전에 `git checkout <head_ref>`로 detached HEAD를 벗어나 실제 브랜치로 올라타려 한다.
4. 해당 파일이 merge HEAD와 브랜치 tip에서 내용이 다르고 워킹트리엔 포맷팅 변경까지 얹혀 있어, git이 덮어쓰기 방지로 checkout을 abort → exit 1 → 워크플로 실패.

이 PR만의 문제가 아니라, Prettier가 건드리는 파일이 main과 갈라진 어떤 PR에서든 재현되는 공유 워크플로의 잠재 버그다.

## Changes

- `.github/workflows/helm-template-check.yml` Checkout 스텝에 `ref: ${{ github.head_ref }}` 추가 (+주석). 처음부터 실제 PR 브랜치를 체크아웃하면 git-auto-commit 내부의 브랜치 전환이 no-op이 되어 abort가 사라진다. git-auto-commit-action 문서가 `pull_request` 트리거에 대해 권장하는 방식이다.

## Test plan

- [x] YAML 파싱 통과 (`python -c "import yaml; yaml.safe_load(...)"`), `jobs.helm-template.steps[0].with.ref == "${{ github.head_ref }}"` 확인
- [ ] jce-service-helm PR #546(feat/live-tweaker-minimax-image)에서 이 워크플로 재실행 → git-auto-commit 스텝 통과 확인

## Notes

- `github.head_ref`는 `pull_request` 이벤트에서만 채워진다. 이 워크플로는 caller가 `on: pull_request`로만 호출하므로 안전하다.
- 이 레포의 `deploy.yml` / `build_v2.yml`도 `ref` 없는 checkout이지만 git-auto-commit을 쓰지 않아 이 버그와 무관하므로 건드리지 않았다.
- 상단의 `Node 20 is being deprecated` 로그는 별개의 비치명 경고(`setup-node node-version: '20'`)로, 이번 수정 범위 밖이다.