### PR TITLE
[INF-383] 빌드·배포 워크플로우 액션 Node 24 대응 및 punycode 경고 해결

### DIFF
--- a/.github/workflows/build_v2.yml
+++ b/.github/workflows/build_v2.yml
@@ -120,7 +120,7 @@ jobs:
         sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$RUNNER_TOOL_CACHE"
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.ref_name }} # 브랜치의 최신 커밋을 체크아웃합니다.
         submodules: recursive # 서브모듈 초기화
@@ -129,7 +129,7 @@ jobs:
     # buildx는 빠른 도커 백엔드입니다. 빌드 속도 개선을 위해 추가했습니다.
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Name tag
       id: name-tag
@@ -158,7 +158,7 @@ jobs:
     # AWS 관련 작업
     - name: Configure AWS credentials
       if: ${{ steps.check-platform.outputs.contains_aws == 'true' }}
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: arn:aws:iam::631535140228:role/ped-role-github-actions
         aws-region: ap-northeast-2
@@ -171,7 +171,7 @@ jobs:
     # NCP 관련 작업
     - name: Login to NCP Container Registry
       if: ${{ steps.check-platform.outputs.contains_ncp == 'true' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ fromJSON(inputs.updateTargets).ncp.registry }}
         username: ${{ secrets.NCP_ACCESS_KEY_ID }}
@@ -211,7 +211,7 @@ jobs:
         echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
     - name: Build and push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         push: true
         # ECR BASIC 스캔은 OCI image index 를 못 읽으므로 단일 매니페스트로 강제 (단일 amd64 빌드라 attestation 손실 없음)
@@ -252,7 +252,7 @@ jobs:
       run: echo '${{ inputs.updateTargets }}' > updateTargets.json
 
     - name: Checkout to Helm Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: team-monolith-product/${{ inputs.helmRepository }}
         path: ${{ inputs.helmRepository }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: develop
           fetch-depth: 0
@@ -38,14 +38,14 @@ jobs:
           git push origin develop
 
       - name: Add success reaction
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ inputs.comment_id }}
-          reaction-type: 'rocket'
+          reactions: 'rocket'
 
       - name: Add failure reaction
         if: failure()
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ inputs.comment_id }}
-          reaction-type: '-1'
+          reactions: '-1'

--- a/.github/workflows/helm-template-check.yml
+++ b/.github/workflows/helm-template-check.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -37,12 +37,12 @@ jobs:
         run: npx prettier --write .
 
       - name: Commit formatting changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'style: apply Prettier and ESLint formatting'
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Run Helm template check
         env:


### PR DESCRIPTION
# 요구 사항
- 어드민 React 빌드 로그의 GitHub Actions Node 20 deprecation 및 `docker/login-action` `punycode` 경고 대응 (INF-383)
- 빌드 로그 경고의 실제 발생지가 이 공유 재사용 워크플로우이므로 여기서 정비
- 같은 레포 내 다른 워크플로우의 Node 20 액션도 전수 정비

# 변경 사항
- `build_v2.yml`
  - `actions/checkout` v4→v7 (×2)
  - `docker/setup-buildx-action` v3→v4
  - `aws-actions/configure-aws-credentials` v4→v6
  - `docker/login-action` v3→v4 (`punycode` DEP0040 경고 해결)
  - `docker/build-push-action` v5→v7
- `deploy.yml`
  - `actions/checkout` v4→v7
  - `peter-evans/create-or-update-comment` v2→v5 (+ `reaction-type`→`reactions` 입력 리네임)
- `helm-template-check.yml`
  - `actions/checkout` v4→v7
  - `stefanzweifel/git-auto-commit-action` v5→v7
  - `azure/setup-helm` v4→v5
- 유지: `aws-actions/amazon-ecr-login@v2`·`actions/setup-node@v6`(이미 node24), `mikefarah/yq@v4`(docker 액션)

# 기타
- ⚠️ 이 워크플로우는 **모든 제품 레포의 빌드·배포에 공유**됩니다. 머지 시 전 레포 CI에 영향.
- 각 major의 breaking change를 사용 입력과 대조 (전부 호환)
  - `configure-aws-credentials` v5 breaking = invalid boolean 입력 처리 변경 → 문자열 입력만 사용해 무관
  - `build-push-action` v6 = build summary 기본 생성(무해), v7 = node24
  - `git-auto-commit-action` v6 = `create_branch`·`skip_checkout`·`skip_fetch` 제거 → `commit_message`만 사용해 무관
  - `azure/setup-helm` v5 = node24 런타임 변경만
  - `create-or-update-comment` v3+ = `reaction-type` 제거 → `reactions`로 리네임 (`rocket`·`-1` 값 유효)
- node24 액션은 러너 v2.327.1+ 필요 — GitHub-hosted 러너는 충족

🤖 Generated with [Claude Code](https://claude.com/claude-code)